### PR TITLE
Add `set -e` to shell scripts to stop them on errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+# Release 20160111-01
+
+### New seed data
+* seed/mecab-user-dict-seed.20160111.csv.xz
+	execute: Periodic data update on 2016-01-11(Mon)
+	commit: https://github.com/neologd/mecab-ipadic-neologd/commit/4e5f09df1ac31bc305e269c33d0d003b451aac79
+
 # Release 20160107-01
 
 ### New seed data

--- a/bin/install-mecab-ipadic-neologd
+++ b/bin/install-mecab-ipadic-neologd
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 BASEDIR=$(cd $(dirname $0);pwd)
 PROGRAM_NAME=install-mecab-ipadic-neologd
 ECHO_PREFIX="[${PROGRAM_NAME}] :"

--- a/libexec/copy-dict-seed.sh
+++ b/libexec/copy-dict-seed.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 BASEDIR=$(cd $(dirname $0);pwd)
 ECHO_PREFIX="[copy-dict-seed] :"
 

--- a/libexec/git_rm_from_log_too.sh
+++ b/libexec/git_rm_from_log_too.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ set -e
+
  FILE_PATH=$1
  ECHO_PREFIX='[git_rm_from_history_too] '
 

--- a/libexec/iconv_euc_to_utf8.sh
+++ b/libexec/iconv_euc_to_utf8.sh
@@ -16,5 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 FILE_NAME=$1
 iconv -f EUC-JP -t UTF-8 ${FILE_NAME} > ${FILE_NAME}.utf8

--- a/libexec/install-mecab-ipadic-neologd.sh
+++ b/libexec/install-mecab-ipadic-neologd.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 BASEDIR=$(cd $(dirname $0);pwd)
 ECHO_PREFIX="[install-mecab-ipadic-neologd] :"
 

--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 BASEDIR=$(cd $(dirname $0);pwd)
 ECHO_PREFIX="[make-mecab-ipadic-neologd] :"
 

--- a/libexec/test-mecab-ipadic-neologd.sh
+++ b/libexec/test-mecab-ipadic-neologd.sh
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 BASEDIR=$(cd $(dirname $0);pwd)
 ECHO_PREFIX="[test-mecab-ipadic-neologd] :"
 


### PR DESCRIPTION
If you write `set -e` in a shell script, it immediately halts when sub-command causes an error.
