### PR TITLE
[DOC]install file command in ubuntu

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+# Release 20160616-01
+
+### New seed data
+* seed/mecab-user-dict-seed.20160616.csv.xz
+	execute: Periodic data update on 2016-06-16(Thu)
+	commit: https://github.com/neologd/mecab-ipadic-neologd/commit/7fad237a5f58724b078a0deb6eef2b13a1b0147d
+
 # Release 20160613-01
 
 ### New seed data

--- a/README.ja.md
+++ b/README.ja.md
@@ -121,7 +121,7 @@ apt、yum や homebrew でインストールするか、自前でコンパイル
 
 - Ubuntu の場合
 
-    $ sudo aptitude install mecab libmecab-dev mecab-ipadic-utf8 git make curl xz-utils
+    $ sudo aptitude install mecab libmecab-dev mecab-ipadic-utf8 git make curl xz-utils file
 
 - Mac OSX の場合
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Please install at any time other lack library.
 
 - On Ubuntu
 
-    $ sudo aptitude install mecab libmecab-dev mecab-ipadic-utf8 git make curl xz-utils
+    $ sudo aptitude install mecab libmecab-dev mecab-ipadic-utf8 git make curl xz-utils file
 
 - On MacOSX
 


### PR DESCRIPTION
Ubuntu seems not to have `file` command by default.

https://github.com/neologd/mecab-ipadic-neologd/blob/master/bin/install-mecab-ipadic-neologd#L262

I found it when I was writing Dockerfile. If you want to check it, please use this dockerfile.

https://github.com/cocuh/docker-mecab-ipadic-neologd/blob/master/Dockerfile
