### PR TITLE
ignore grep options to prevent from showing line numbers

### DIFF
--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -21,6 +21,7 @@ set -u
 
 BASEDIR=$(cd $(dirname $0);pwd)
 ECHO_PREFIX="[make-mecab-ipadic-NEologd] :"
+GREP_OPTIONS=""
 
 echo "$ECHO_PREFIX Start.."
 

--- a/libexec/test-mecab-ipadic-neologd.sh
+++ b/libexec/test-mecab-ipadic-neologd.sh
@@ -21,6 +21,7 @@ set -u
 
 BASEDIR=$(cd $(dirname $0);pwd)
 ECHO_PREFIX="[test-mecab-ipadic-NEologd] :"
+GREP_OPTIONS=""
 
 echo "$ECHO_PREFIX Start.."
 


### PR DESCRIPTION
Hello,

Thank you for useful dictionary!

When I set `GREP_OPTIONS="--color=auto --line-number"`, install-mecab-ipadic-neologd fails.
The error messages are listed below.

```
./bin/install-mecab-ipadic-neologd -n

#
# ...
#

[make-mecab-ipadic-NEologd] : Start..
[make-mecab-ipadic-NEologd] : Check local seed directory
[make-mecab-ipadic-NEologd] : Check local seed file
[make-mecab-ipadic-NEologd] : /home/username/mecab-ipadic-neologd/libexec/../seed/mecab-user-dict-seed.1:20161003.csv.xz isn't there.
[make-mecab-ipadic-NEologd] : You should execute libexec/copy-dict-seed.sh first.
```

When I set `GREP_OPTIONS=""` the install script finish correctly.

How about ignoring options for grep in make-mecab-ipadic-neologd.sh and test-mecab-ipadic-neologd.sh?
