### PR TITLE
Fix merge mistake when periodic data update on 2019-04-15

### DIFF
--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -369,11 +369,7 @@ else
     echo "${ECHO_PREFIX} We can't intall ${BASEDIR}/../seed/${ADJECTIVE_VERB_SEED_FILE_NAME}"
 fi
 
-<<<<<<< HEAD
 INFREQ_DATETIME_SEED_FILE_NAME=neologd-date-time-infreq-dict-seed.20190415.csv
-=======
-INFREQ_DATETIME_SEED_FILE_NAME=neologd-date-time-infreq-dict-seed.20181004.csv
->>>>>>> 2a6390789b3e50cbd26ba2bf93f6cda545f39b60
 if [ -f ${BASEDIR}/../seed/${INFREQ_DATETIME_SEED_FILE_NAME}.xz ]; then
     if [ ${WANNA_INSRALL_ALL_SEED_FILES} -gt 0 ]; then
         WANNA_INSTALL_INFREQ_DATETIME=1
@@ -394,11 +390,7 @@ else
     echo "${ECHO_PREFIX} We can't intall ${BASEDIR}/../seed/${INFREQ_DATETIME_SEED_FILE_NAME}"
 fi
 
-<<<<<<< HEAD
 INFREQ_QUANTITY_SEED_FILE_NAME=neologd-quantity-infreq-dict-seed.20190415.csv
-=======
-INFREQ_QUANTITY_SEED_FILE_NAME=neologd-quantity-infreq-dict-seed.20181004.csv
->>>>>>> 2a6390789b3e50cbd26ba2bf93f6cda545f39b60
 if [ -f ${BASEDIR}/../seed/${INFREQ_QUANTITY_SEED_FILE_NAME}.xz ]; then
     if [ ${WANNA_INSRALL_ALL_SEED_FILES} -gt 0 ]; then
         WANNA_INSTALL_INFREQ_QUANTITY=1


### PR DESCRIPTION
## What is this PR for?

It was corrected because there was a merge mistake.

```
[make-mecab-ipadic-NEologd] : Install adjective verb orthographic variant entries using /home/username/mecab-ipadic-neologd/libexec/../seed/neologd-adjective-verb-dict-seed.20160324.csv.xz
/home/username/mecab-ipadic-neologd/bin/../libexec/make-mecab-ipadic-neologd.sh: line 372: syntax error near unexpected token `<<<'
```

## This PR includes

Nothing

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Execute the following command to confirm that the installation is possible.

```
$ ./bin/install-mecab-ipadic-neologd -n -y
```