### PR TITLE
Correcting the README for CentOS 7

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -135,7 +135,7 @@ apt、yum や homebrew でインストールするか、自前でコンパイル
 
     $ sudo rpm -ivh http://packages.groonga.org/centos/groonga-release-1.1.0-1.noarch.rpm
 
-    $ sudo yum install mecab mecab-devel mecab-ipadic git make curl xz
+    $ sudo yum install mecab mecab-devel mecab-ipadic git make curl xz patch
 
 - Fedora の場合
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Please install at any time other lack library.
 
     $ sudo rpm -ivh http://packages.groonga.org/centos/groonga-release-1.1.0-1.noarch.rpm
 
-    $ sudo yum install mecab mecab-devel mecab-ipadic git make curl xz
+    $ sudo yum install mecab mecab-devel mecab-ipadic git make curl xz patch
 
 - On Fedora
 


### PR DESCRIPTION
## What is this PR for?

@worthmine reported that the README for CentOS 7 has a missing 'patch' package.

## This PR includes

- Add 'patch'

## What type of PR is it?

Bugfix

## What is the issue?

#56 

## How should this be tested?

TBD