### PR TITLE
Generate packages and publish them to Bintray + GitHub Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+target/
+.idea/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,170 @@
-language: bash
+language: python
+python: "3.7"
+dist: xenial
 
 notifications:
- email: false
+  email: false
 
-before_install:
- - mkdir ./target
+env:
+  global:
+    - INSTALL_TARGET=./target
 
-cache: apt
+    # GitHub personal access token ("GITHUB_OAUTH_TOKEN" environment variable)
+    # (https://docs.travis-ci.com/user/deployment/releases/#authenticating-with-an-oauth-token)
+    #
+    # 1. Go to https://github.com/settings/tokens
+    # 2. Create new token with "public_repo" permission
+    # 3. Encrypt token by running:
+    #
+    #     travis encrypt GITHUB_OAUTH_TOKEN=<token>
+    #
+    # 4. Paste it here
+    - secure: "lvuKx12lUDDyCtfhxPDmpwHiPl2PgvH7Bx/a2jYm/BxLdqzbxWFf0aeul8sL4HA5ECU9zZfMRDhJ1xEx+z9uiY+RREPfGoqJFExqtCN1QZtq+mZ5ep2E7NrgxeHbzEpoTVhqXhxUyPnJw4pQ6eYQXgmcYVkneXnJqG7P5n5mYSLhEplNdR6VrNeBqxRzzXRGesjNaMs2NT9BvxemcCftDVzYRnVX+N6RiUumwpMgVTPOXuEJmqRJGih00XTNM/RdL56SUW9A8fm13a21vb28lt8qK6N47Op/7mPTkkGPDJGybXFtfoFcDQpY2PWPw2zBGXZt19ql6b5XJy5m43IFYywUtuL5/zA34CORYXYYJC1JJvC2pvEc30RlxKZCoBg5s+3q9rsUFYD154k0GsC0wh/gJeMrzK2u57trUwunC7LEgAyivvgGgsXjVqA/nMZ21Xpgj3eL8nBNmfCUUBWZMgkb6zv5k7kkOnGntG6vPTCSISuZCHMp3NmDQglv2iRS2sg9Y/JxYFmrT3OUStRwQpJ+lekDiDcS72M8H92Xhrzn8GR1ampYZYTceUChvxENfMbWEv4echANlOx7VvRShU159+CxZIS6O5L7iEKF7oH97NBMyxxSHmg2YsHOXijgzH8j5ykDLep2yvgdV97PDonPNmbXizF+Lxx/7wSTRvo="
+
+    # Bintray username to use for logging in
+    - BINTRAY_USERNAME=mediacloud-artifacts
+
+    # Bintray API key ("BINTRAY_API_KEY" environment variable)
+    #
+    # 1. Go to https://bintray.com/profile/edit
+    # 2. Click "API Key"
+    # 4. Encrypt API key by running:
+    #
+    #     travis encrypt BINTRAY_API_KEY=<api_key>
+    #
+    # 5. Paste it here
+    - secure: "mj/fE5sBPGXI74JhZmey9PTOHIYM4O8FOLWNuZzTzYPbKE6AsNmf2ZZRFOUqqAetuD7gdvhrJIE1YJSPZ1GvKzxqQyv6PkvkXLw3E4D8p1i4o9nD++uO3S9tWJM3dWYrGVE9YTpmhcqhS7DsTxrjAOSDHjijxIp/RKQMzp6zC9qc9lJctwWX/rt6v2GUW/1F/1GBvFv53wGbbkasVq3nBfgSpftGVcJI7Yg0oR5hlA7seGilxLb3tjPMHLEsIKqQgB08LjT8NQJ0HR3K3Mr6N6N1gB9bgCdLb6FYCa41GHFB80F+TERitfH9dcMYTwyWb6gNgEvEAhi4QVm+KgX6XyuDYPYD6ldY3psfLeS5eYg8QVWeCPv4nCda9DqxtGxx1O6EF8yxYIXSs2j5z05TNPnjjxSjIKBf0vdP189Ep7/7xwYPwC8YfDCQtlqivqzrpFm9wqMRzTX0+zhLxHCrXvfr5Ufb6PghWApgS9J4O+7024/PKFx6blLoXHPF23gjXA0nW8jPCpKWv7PV2+lbtsxrb2AVSHbiULaEsgKW19rjh5dzUdsJhUrwhedz4DB64k2VL48OkUsxzLbk6mXUslYsBxgC0vzFxzdpotn5vhZt2PxkvuXfsFKkw69Enw2tAput/feOVVvsh3vPTXxYq36sCxtVeBgwg9afW8MezU4="
+
+    # Bintray user or organization that owns the repository
+    - BINTRAY_SUBJECT=neologd-unofficial
+
+    # Bintray repository names for each type of package
+    - BINTRAY_REPOSITORY_TGZ=mecab-ipadic-neologd-tgz
+    - BINTRAY_REPOSITORY_DEB=mecab-ipadic-neologd-deb
+    - BINTRAY_REPOSITORY_RPM=mecab-ipadic-neologd-rpm
+
+    # Temporary paths to save generated packages to
+    - PACKAGE_PATH_TGZ=$HOME/mecab-ipadic-neologd-$TRAVIS_TAG.tgz
+    - PACKAGE_PATH_DEB=$HOME/mecab-ipadic-neologd-$TRAVIS_TAG.deb
+    - PACKAGE_PATH_RPM=$HOME/mecab-ipadic-neologd-$TRAVIS_TAG.rpm
+
+    # Temporary paths to Bintray descriptor JSON files to generate
+    - BINTRAY_DESCRIPTOR_TGZ=$HOME/bintray-tgz.json
+    - BINTRAY_DESCRIPTOR_DEB=$HOME/bintray-deb.json
+    - BINTRAY_DESCRIPTOR_RPM=$HOME/bintray-rpm.json
+
+install:
+  - gem install --no-ri --no-rdoc fpm
 
 addons:
   apt:
     packages:
-    - mecab
-    - libmecab-dev
-    - mecab-ipadic-utf8
-    - git
-    - make
-    - curl
-    - xz-utils
-    - file
+      - build-essential
+      - curl
+      - file
+      - git
+      - libmecab-dev
+      - make
+      - mecab
+      - mecab-ipadic-utf8
+      - rpm
+      - ruby
+      - ruby-dev
+      - xz-utils
 
-install:
- - bash ./libexec/make-mecab-ipadic-neologd.sh -p /home/travis/build/neologd/mecab-ipadic-neologd/target/neologd-travisci -s 0 -l 0 -S 0 -L 0 -u 0 -B 0 -J 0 -O 0 -H 0 -t 0 -T 1 -j 0 -E 0 -G ""
+before_script:
+  - mkdir $INSTALL_TARGET
 
 script:
- - bash ./libexec/test-mecab-ipadic-neologd.sh
+  - bash ./bin/install-mecab-ipadic-neologd --prefix `readlink -m $INSTALL_TARGET`
+
+after_success:
+
+  # Create .tgz
+  - >
+      if [[ "$TRAVIS_TAG" != "" ]]; then python3 ./libexec/create_package.py
+      --type tgz
+      --input_dir $INSTALL_TARGET
+      --version_tag $TRAVIS_TAG
+      --output_file $PACKAGE_PATH_TGZ
+      --bintray_descriptor_file $BINTRAY_DESCRIPTOR_TGZ
+      --bintray_repository_name $BINTRAY_REPOSITORY_TGZ
+      --bintray_subject $BINTRAY_SUBJECT; fi
+
+  # Create .deb
+  - >
+      if [[ "$TRAVIS_TAG" != "" ]]; then python3 ./libexec/create_package.py
+      --type deb
+      --input_dir $INSTALL_TARGET
+      --version_tag $TRAVIS_TAG
+      --output_file $PACKAGE_PATH_DEB
+      --bintray_descriptor_file $BINTRAY_DESCRIPTOR_DEB
+      --bintray_repository_name $BINTRAY_REPOSITORY_DEB
+      --bintray_subject $BINTRAY_SUBJECT; fi
+
+  # Create .rpm
+  - >
+      if [[ "$TRAVIS_TAG" != "" ]]; then python3 ./libexec/create_package.py
+      --type rpm
+      --input_dir $INSTALL_TARGET
+      --version_tag $TRAVIS_TAG
+      --output_file $PACKAGE_PATH_RPM
+      --bintray_descriptor_file $BINTRAY_DESCRIPTOR_RPM
+      --bintray_repository_name $BINTRAY_REPOSITORY_RPM
+      --bintray_subject $BINTRAY_SUBJECT; fi
+
+deploy:
+
+  # Deploy .tgz to Bintray
+  - provider: bintray
+    file: "$BINTRAY_DESCRIPTOR_TGZ"
+    user: "$BINTRAY_USERNAME"
+    key: "$BINTRAY_API_KEY"
+    skip_cleanup: true
+    on:
+      tags: true
+
+  # Deploy .deb to Bintray
+  - provider: bintray
+    file: "$BINTRAY_DESCRIPTOR_DEB"
+    user: "$BINTRAY_USERNAME"
+    key: "$BINTRAY_API_KEY"
+    skip_cleanup: true
+    on:
+      tags: true
+
+  # Deploy .rpm to Bintray
+  - provider: bintray
+    file: "$BINTRAY_DESCRIPTOR_RPM"
+    user: "$BINTRAY_USERNAME"
+    key: "$BINTRAY_API_KEY"
+    skip_cleanup: true
+    on:
+      tags: true
+
+  # Deploy .tgz to GitHub Releases
+  - provider: releases
+    api_key: "$GITHUB_OAUTH_TOKEN"
+    file: "$PACKAGE_PATH_TGZ"
+    skip_cleanup: true
+    overwrite: true
+    on:
+      tags: true
+
+  # Deploy .deb to GitHub Releases
+  - provider: releases
+    api_key: "$GITHUB_OAUTH_TOKEN"
+    file: "$PACKAGE_PATH_DEB"
+    skip_cleanup: true
+    overwrite: true
+    on:
+      tags: true
+
+  # Deploy .rpm to GitHub Releases
+  - provider: releases
+    api_key: "$GITHUB_OAUTH_TOKEN"
+    file: "$PACKAGE_PATH_RPM"
+    skip_cleanup: true
+    overwrite: true
+    on:
+      tags: true

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+# Release 20190911-01
+
+### New seed data
+* seed/mecab-user-dict-seed.20190911.csv.xz
+	execute: Periodic data update on 2019-09-11(Wed)
+	commit: https://github.com/neologd/mecab-ipadic-neologd/commit/87ea03e48e7b577071b3d6dfdf740fc363190022
+
 # Release 20190905-01
 
 ### New seed data

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 
 ### New seed data
 * seed/mecab-user-dict-seed.20190911.csv.xz
-	execute: Periodic data update on 2019-09-11(Wed)
+	execute: Nonperiodic data update on 2019-09-11(Wed)
 	commit: https://github.com/neologd/mecab-ipadic-neologd/commit/87ea03e48e7b577071b3d6dfdf740fc363190022
 
 # Release 20190905-01

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 # mecab-ipadic-NEologd : Neologism dictionary for MeCab
 <img src="https://raw.githubusercontent.com/neologd/mecab-ipadic-neologd/images/neologd-logo-September2016.png" width="250">
 
-[![Build Status](https://travis-ci.org/neologd/mecab-ipadic-neologd.svg?branch=master)](https://travis-ci.org/neologd/mecab-ipadic-neologd)
+[![Build Status](https://travis-ci.org/pypt/mecab-ipadic-neologd-publish-builds.svg?branch=master)](https://travis-ci.org/pypt/mecab-ipadic-neologd-publish-builds)
 
 ## 詳細な情報
 mecab-ipadic-NEologd に関する詳細な情報(サンプルコードなど)は以下の Wiki に書いてあります。

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mecab-ipadic-NEologd : Neologism dictionary for MeCab
 <img src="https://raw.githubusercontent.com/neologd/mecab-ipadic-neologd/images/neologd-logo-September2016.png" width="250">
 
-[![Build Status](https://travis-ci.org/neologd/mecab-ipadic-neologd.svg?branch=master)](https://travis-ci.org/neologd/mecab-ipadic-neologd)
+[![Build Status](https://travis-ci.org/pypt/mecab-ipadic-neologd-publish-builds.svg?branch=master)](https://travis-ci.org/pypt/mecab-ipadic-neologd-publish-builds)
 
 ## For Japanese
 README.ja.md is written in Japanese.
@@ -51,7 +51,59 @@ When you analyze the Web documents, it's better to use this system dictionary an
 - Corresponding to only UTF-8
     - You should install the UTF-8 version of MeCab
 
-## Getting started
+## Installing mecab-ipadic-NEologd
+
+### Debian / Ubuntu
+
+You can download pre-build mecab-ipadic-neologd `.deb` packages via APT:
+
+```bash
+# Add Bintray's GPG key
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+
+# Add mecab-ipadic-neologd APT repository
+echo "deb https://dl.bintray.com/neologd-unofficial/mecab-ipadic-neologd-deb stable main" | sudo tee -a /etc/apt/sources.list.d/mecab-ipadic-neologd.list
+
+# Update APT package listing
+sudo apt-get -y update
+
+# Install mecab-ipadic-neologd
+sudo apt-get -y install mecab-ipadic-neologd
+```
+
+or from our [GitHub releases](releases) page.
+
+mecab-ipadic-NEologd data files will be available at `/var/lib/mecab/dic/ipadic-neologd`.
+
+### Red Hat / CentOS
+
+You can download pre-build mecab-ipadic-neologd `.rpm` packages via YUM:
+
+```bash
+# Add repository that provides mecab RPM
+sudo yum install -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
+sudo yum makecache
+
+# Add mecab-ipadic-neologd YUM repository
+sudo curl https://bintray.com/neologd-unofficial/mecab-ipadic-neologd-rpm/rpm -o /etc/yum.repos.d/mecab-ipadic-neologd.repo
+
+# Install mecab-ipadic-neologd
+sudo yum install -y mecab-ipadic-neologd
+```
+
+or from our [GitHub releases](releases) page.
+
+mecab-ipadic-NEologd data files will be available at `/usr/lib64/mecab/dic/ipadic-neologd`.
+
+### Tarball
+
+You can download pre-build mecab-ipadic-NEologd tarball packages from:
+
+**<https://bintray.com/neologd-unofficial/mecab-ipadic-neologd-tgz>**
+
+or from our [GitHub releases](releases) page.
+
+## Building mecab-ipadic-NEologd yourself
 
 ### Memory requirements
 - Required: 1.5GB of RAM

--- a/bin/install-mecab-ipadic-neologd
+++ b/bin/install-mecab-ipadic-neologd
@@ -390,29 +390,6 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
-function wanna_install(){
-    while true;do
-        echo ""
-        echo "$ECHO_PREFIX Please check the list of differences in the upper part."
-        echo ""
-        echo "$ECHO_PREFIX Do you want to install mecab-ipadic-NEologd? Type yes or no."
-        read answer
-        case $answer in
-            yes)
-                return 0
-                ;;
-            no)
-                echo "$ECHO_PREFIX Quit from installing process"
-                echo "$ECHO_PREFIX Finish.."
-                exit
-                ;;
-            *)
-                echo -e "cannot understand $answer.\n"
-                ;;
-        esac
-    done
-}
-
 if [ ${IS_FORCE_YES} -eq 0 ]; then
 
     echo "$ECHO_PREFIX Get results of tokenize test"
@@ -425,8 +402,6 @@ if [ ${IS_FORCE_YES} -eq 0 ]; then
         usage
         exit 1
     fi
-
-    wanna_install
 fi
 
 echo "$ECHO_PREFIX OK. Let's install mecab-ipadic-NEologd."

--- a/libexec/create_package.py
+++ b/libexec/create_package.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+
+"""
+Create .tgz / .deb / .rpm packages of mecab-ipadic-neologd.
+
+Requires fpm:
+
+    gem install --no-ri --no-rdoc fpm
+
+"""
+from abc import ABC, ABCMeta, abstractmethod
+import argparse
+import datetime
+import errno
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from typing import Optional, List
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+class MeCabPackageException(Exception):
+    """Exception thrown when package generation fails."""
+    pass
+
+
+class PackageConfig(object):
+    """Package configuration."""
+
+    @classmethod
+    def name(cls) -> str:
+        """
+        Return package name
+        :return: Package name.
+        """
+        return "mecab-ipadic-neologd"
+
+    @classmethod
+    def summary(cls) -> str:
+        """
+        Return package summary.
+        :return: Package summary.
+        """
+        return "(Unofficial build) Neologism dictionary based on the language resources on the Web for mecab-ipadic"
+
+    @classmethod
+    def license(cls) -> str:
+        """
+        Return package license.
+        :return: Package license.
+        """
+        return "Apache-2.0"
+
+    @classmethod
+    def vendor(cls) -> str:
+        """
+        Return package vendor.
+        :return: Package vendor.
+        """
+        return "Toshinori Sato (@overlast) <overlasting@gmail.com>"
+
+    @classmethod
+    def maintainer(cls) -> str:
+        """
+        Return package maintainer.
+        :return: Package maintainer.
+        """
+        return "Linas Valiukas <linas@media.mit.edu>"
+
+    @classmethod
+    def url(cls) -> str:
+        """
+        Return package URL.
+        :return: Package URL.
+        """
+        return "https://github.com/pypt/mecab-ipadic-neologd-publish-builds"
+
+    @classmethod
+    def git_url(cls) -> str:
+        """
+        Return package Git URL.
+        :return: Package Git URL.
+        """
+        return cls.url() + ".git"
+
+    @classmethod
+    def depends_mecab_version(cls) -> str:
+        """
+        Return MeCab version the package depends on.
+        :return: MeCab version the package depends on.
+        """
+        return "0.996"
+
+    @classmethod
+    def changelog_file(cls) -> str:
+        """
+        Return changelog filename.
+        :return: Changelog filename.
+        """
+        return 'ChangeLog'
+
+    @classmethod
+    def tags(cls) -> List[str]:
+        """
+        Return list of package tags.
+        :return: List of package tags.
+        """
+        return [
+            'mecab-ipadic',
+            'named-entities',
+            'dictionary',
+            'furigana',
+            'neologism-dictionary',
+            'mecab',
+            'language-resources',
+            'japanese-language',
+        ]
+
+    @classmethod
+    def misc_docs(cls) -> List[str]:
+        """
+        Return list of absolute paths to documentation files.
+        :return: List of absolute paths to documentation files.
+        """
+        path_to_root = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+        return [
+            os.path.join(path_to_root, 'README.md'),
+            os.path.join(path_to_root, 'README.ja.md'),
+            os.path.join(path_to_root, cls.changelog_file()),
+            os.path.join(path_to_root, 'COPYING'),
+        ]
+
+
+class PackageGenerator(object, metaclass=ABCMeta):
+    """Abstract package generator."""
+
+    @classmethod
+    def _run_command(cls, command: List[str], cwd: Optional[str] = None) -> None:
+        """
+        Run command, forward output to logger.
+
+        :param command: Command to run.
+        :param cwd: Directory to change to before running a command; None if the directory shouldn't be changed.
+        """
+        line_buffered = 1
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=line_buffered,
+            cwd=cwd,
+        )
+
+        while True:
+            output = process.stdout.readline()
+            if len(output) == 0 and process.poll() is not None:
+                break
+            logging.info(output.strip())
+        rc = process.poll()
+        if rc > 0:
+            raise MeCabPackageException("Process returned non-zero exit code %d" % rc)
+
+    @classmethod
+    def _mkdir_p(cls, path: str) -> None:
+        """
+        Create directory with parent directories.
+
+        :param path: Path of directories to create.
+        """
+        try:
+            os.makedirs(path)
+        except OSError as exc:  # Python >2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise
+
+    @classmethod
+    def _link_dictionaries_and_docs(cls, input_dir: str, lib_dir: str, doc_dir: str, config: PackageConfig) -> None:
+        """
+        Hardlink dictionary files from input directory and documentation to target directory.
+        :param input_dir: Input directory with dictionary files.
+        :param lib_dir: Output library directory where dictionary files should reside.
+        :param doc_dir: Output documentation directory where docs should reside
+        """
+        cls._mkdir_p(lib_dir)
+        cls._mkdir_p(doc_dir)
+
+        logging.info('Linking MeCab files to library directory...')
+        for filename in os.listdir(input_dir):
+            full_filename = os.path.join(input_dir, filename)
+            if os.path.isfile(full_filename):
+                os.link(full_filename, os.path.join(lib_dir, filename))
+
+        logging.info('Linking documentation files to documentation directory...')
+        for doc_file_path in config.misc_docs():
+            os.link(doc_file_path, os.path.join(doc_dir, os.path.basename(doc_file_path)))
+
+    @classmethod
+    @abstractmethod
+    def package_type(cls) -> str:
+        """
+        Return package type to use for arguments.
+        :return: Package type to use for arguments, e.g. "tgz".
+        """
+        raise NotImplemented("Abstract method.")
+
+    @classmethod
+    @abstractmethod
+    def expected_extension(cls) -> str:
+        """
+        Return expected extension for this package type.
+        :return: Expected extension for this package type, e.g. ".tgz".
+        """
+        raise NotImplemented("Abstract method.")
+
+    @classmethod
+    @abstractmethod
+    def generate_package(cls,
+                         input_dir: str,
+                         version: str,
+                         revision: str,
+                         output_file: str,
+                         config: PackageConfig) -> None:
+        """
+        Generate package of built dictionary.
+
+        :param input_dir: Directory with staged dictionary to use for packaging.
+        :param version: Package version, e.g. "20170814".
+        :param revision: Package revision, e.g. "1".
+        :param output_file: Output file to write the package to, e.g. "test.tgz".
+        :param config: Package configuration.
+        """
+        raise NotImplemented("Abstract method.")
+
+
+class TGZPackageGenerator(PackageGenerator):
+    """.tgz package generator."""
+
+    @classmethod
+    def package_type(cls) -> str:
+        return 'tgz'
+
+    @classmethod
+    def expected_extension(cls) -> str:
+        return '.tgz'
+
+    @classmethod
+    def generate_package(cls,
+                         input_dir: str,
+                         version: str,
+                         revision: str,
+                         output_file: str,
+                         config: PackageConfig) -> None:
+        temp_dir = tempfile.mkdtemp()
+        mecab_dirname = '%(name)s-%(version)s-%(revision)s' % {
+            'name': config.name(),
+            'version': version,
+            'revision': revision,
+        }
+        lib_doc_dir = os.path.join(temp_dir, mecab_dirname)
+        os.mkdir(lib_doc_dir)
+        logging.debug('Temporary MeCab tarball directory: %s' % lib_doc_dir)
+
+        cls._link_dictionaries_and_docs(input_dir=input_dir, lib_dir=lib_doc_dir, doc_dir=lib_doc_dir, config=config)
+
+        if os.path.isfile(output_file):
+            logging.info("Removing previously built TGZ package at %s..." % output_file)
+            os.unlink(output_file)
+
+        logging.info('Creating "%s"...' % output_file)
+
+        cls._run_command(['tar', '-czvf', output_file, mecab_dirname], cwd=temp_dir)
+
+        logging.info('Cleaning up temporary directory...')
+        shutil.rmtree(lib_doc_dir)
+
+        logging.info('Resulting tarball: %s' % output_file)
+
+
+class FPMBasedPackageGenerator(PackageGenerator, ABC):
+    """Abstract FPM-based package generator."""
+
+    @classmethod
+    def _fpm_common_flags(cls, version: str, revision: str, config: PackageConfig) -> List[str]:
+        return [
+            '--verbose',
+            '--input-type', 'dir',
+            '--name', config.name(),
+            '--version', version,
+            '--iteration', revision,
+            '--description', config.summary(),
+            '--license', config.license(),
+            '--vendor', config.vendor(),
+            '--maintainer', config.maintainer(),
+            '--url', config.url(),
+            '--architecture', 'all',
+            '--prefix', '/',
+        ]
+
+
+class DEBPackageGenerator(FPMBasedPackageGenerator):
+    """.deb package generator."""
+
+    @classmethod
+    def package_type(cls) -> str:
+        return 'deb'
+
+    @classmethod
+    def expected_extension(cls) -> str:
+        return '.deb'
+
+    @classmethod
+    def generate_package(cls,
+                         input_dir: str,
+                         version: str,
+                         revision: str,
+                         output_file: str,
+                         config: PackageConfig) -> None:
+        deb_source_dir = tempfile.mkdtemp()
+
+        deb_base_lib_dir = 'var/lib/mecab/dic/ipadic-neologd'
+        deb_base_doc_dir = 'usr/share/doc/mecab-ipadic-neologd'
+
+        lib_dir = os.path.join(deb_source_dir, deb_base_lib_dir)
+        doc_dir = os.path.join(deb_source_dir, deb_base_doc_dir)
+
+        cls._link_dictionaries_and_docs(input_dir=input_dir, lib_dir=lib_dir, doc_dir=doc_dir, config=config)
+
+        deb_name = '%(name)s_%(version)s-%(revision)s_all.deb' % {
+            'name': config.name(),
+            'version': version,
+            'revision': revision,
+        }
+
+        if os.path.isfile(output_file):
+            logging.info("Removing previously built DEB package at %s..." % output_file)
+            os.unlink(output_file)
+
+        after_install_path = os.path.join(tempfile.mkdtemp(), 'after-install')
+        with open(after_install_path, 'w') as after_install:
+            after_install.write(
+                'update-alternatives --install /var/lib/mecab/dic/debian mecab-dictionary /%s 100' % deb_base_lib_dir
+            )
+
+        after_remove_path = os.path.join(tempfile.mkdtemp(), 'after-remove')
+        with open(after_remove_path, 'w') as after_remove:
+            after_remove.write('update-alternatives --remove mecab-dictionary /%s' % deb_base_lib_dir)
+
+        logging.info('Creating %s...' % deb_name)
+        fpm_command = ['fpm'] + cls._fpm_common_flags(version=version, revision=revision, config=config) + [
+            '--output-type', 'deb',
+            '--package', output_file,
+            '--chdir', deb_source_dir,
+            '--depends', 'mecab (>= %s)' % config.depends_mecab_version(),
+            '--category', 'misc',
+            '--deb-priority', 'extra',
+            '--deb-no-default-config-files',
+            '--after-install', after_install_path,
+            '--after-remove', after_remove_path,
+        ]
+        logging.debug(fpm_command)
+        cls._run_command(fpm_command)
+
+        logging.info('Cleaning up temporary directory...')
+        shutil.rmtree(deb_source_dir)
+
+        logging.info('Resulting .deb: %s' % output_file)
+
+
+class RPMPackageGenerator(FPMBasedPackageGenerator):
+    """.rpm package generator."""
+
+    @classmethod
+    def package_type(cls) -> str:
+        return 'rpm'
+
+    @classmethod
+    def expected_extension(cls) -> str:
+        return '.rpm'
+
+    @classmethod
+    def generate_package(cls,
+                         input_dir: str,
+                         version: str,
+                         revision: str,
+                         output_file: str,
+                         config: PackageConfig) -> None:
+        rpm_source_dir = tempfile.mkdtemp()
+
+        lib_dir = os.path.join(rpm_source_dir, 'usr/lib64/mecab/dic/ipadic-neologd')
+        doc_dir = os.path.join(rpm_source_dir, 'usr/share/doc/%s-%s' % (config.name(), version,))
+
+        cls._link_dictionaries_and_docs(input_dir=input_dir, lib_dir=lib_dir, doc_dir=doc_dir, config=config)
+
+        rpm_name = '%(name)s_%(version)s-%(revision)s_all.rpm' % {
+            'name': config.name(),
+            'version': version,
+            'revision': revision,
+        }
+
+        if os.path.isfile(output_file):
+            logging.info("Removing previously built RPM package at %s..." % output_file)
+            os.unlink(output_file)
+
+        logging.info('Creating %s...' % rpm_name)
+        fpm_command = ['fpm'] + cls._fpm_common_flags(version=version, revision=revision, config=config) + [
+            '--output-type', 'rpm',
+            '--package', output_file,
+            '--chdir', rpm_source_dir,
+            '--depends', 'mecab >= %s' % config.depends_mecab_version(),
+            '--category', 'Applications/Text',
+            '--rpm-os', 'linux',
+        ]
+        logging.debug(fpm_command)
+        cls._run_command(fpm_command)
+
+        logging.info('Cleaning up temporary directory...')
+        shutil.rmtree(rpm_source_dir)
+
+        logging.info('Resulting .rpm: %s' % output_file)
+
+
+def bintray_descriptor_json(bintray_repository_name: str,
+                            bintray_subject: str,
+                            version: str,
+                            revision: str,
+                            version_tag: str,
+                            package_path: str,
+                            config: PackageConfig) -> str:
+    """
+    Generate and return Bintray descriptor JSON for a package.
+
+    :param bintray_repository_name: Bintray repository name, e.g. "mecab-ipadic-neologd-tgz".
+    :param bintray_subject: Bintray subject (user or organization), e.g. "neologd-unofficial".
+    :param version: Package version, e.g. "20170814".
+    :param revision: Package revision, e.g. "1".
+    :param version_tag: Git tag, e.g. "20170814" or "20170814-1".
+    :param package_path: Path to package to upload.
+    :param config: Package configuration.
+    :return: Bintray descriptor JSON.
+    """
+    package_dir = os.path.dirname(package_path)
+    package_filename = os.path.basename(package_path)
+    include_pattern = '%s/(%s)' % (package_dir, package_filename,)
+
+    descriptor = {
+        "package": {
+            "name": config.name(),
+            "repo": bintray_repository_name,
+            "subject": bintray_subject,
+            "desc": config.summary(),
+            "website_url": config.url(),
+            "vcs_url": config.git_url(),
+            "github_use_tag_release_notes": True,
+            "github_release_notes_file": config.changelog_file(),
+            "licenses": [
+                config.license(),
+            ],
+            "labels": config.tags(),
+            "public_download_numbers": True,
+            "public_stats": True,
+        },
+
+        "version": {
+            "name": '%s-%s' % (version, revision,),
+            "desc": "%s (%s)" % (version, revision,),
+            "released": datetime.datetime.today().strftime('%Y-%m-%d'),
+            "vcs_tag": version_tag,
+            "gpgSign": True,
+        },
+
+        "files": [
+            {
+                "includePattern": include_pattern,
+                "uploadPattern": "$1",
+                "matrixParams": {
+                    "override": 1,
+
+                    # Used for .deb files only
+                    "deb_distribution": 'stable',
+                    "deb_component": 'main',
+                    "deb_architecture": 'all',
+                }
+            }
+        ],
+        "publish": True,
+    }
+    return json.dumps(descriptor)
+
+
+def main():
+    package_generator_classes = [
+        TGZPackageGenerator,
+        DEBPackageGenerator,
+        RPMPackageGenerator,
+    ]
+
+    parser = argparse.ArgumentParser(description='Generate mecab-ipadic-neologd package.')
+
+    parser.add_argument('--type', required=True, type=str,
+                        choices=[e.package_type() for e in package_generator_classes],
+                        help='Package type to build.')
+    parser.add_argument('--input_dir', required=True, type=str,
+                        help='Input directory with pre-built MeCab dictionary, i.e. the directory with "sys.dic".')
+    parser.add_argument('--version_tag', required=True, type=str,
+                        help='Git version tag, e.g. "20170814" or "20170814-1".')
+    parser.add_argument('--output_file', required=True, type=str,
+                        help="Output package file.")
+
+    parser.add_argument('--bintray_descriptor_file', required=False, type=str,
+                        help="Bintray descriptor file to write; if unset, won't create descriptor.")
+    parser.add_argument('--bintray_repository_name', required=False, type=str,
+                        help='Bintray repository name, e.g. "mecab-ipadic-neologd-tgz".')
+    parser.add_argument('--bintray_subject', required=False, type=str,
+                        help='Bintray subject (user or organization), e.g. "neologd-unofficial".')
+
+    args = parser.parse_args()
+
+    package_generator = next((x for x in package_generator_classes if x.package_type() == args.type), None)
+    if not package_generator:
+        parser.error("Invalid package type: %s" % args.package_type)
+
+    if args.bintray_descriptor_file:
+        if not (args.bintray_repository_name and args.bintray_subject):
+            parser.error("Please provide Bintray descriptor file path, repository name and subject.")
+
+    if not args.output_file.endswith(package_generator.expected_extension()):
+        parser.error("Output file does not end with expected extension '%s'." % package_generator.expected_extension())
+
+    config = PackageConfig()
+
+    if not os.path.isfile(os.path.join(args.input_dir, 'sys.dic')):
+        raise MeCabPackageException('Input directory "%s" does not contain build MeCab dictionary.' % args.input_dir)
+    for misc_doc_file in config.misc_docs():
+        if not os.path.isfile(misc_doc_file):
+            raise MeCabPackageException('Misc. documentation file "%s" does not exist.' % misc_doc_file)
+
+    if '-' in args.version_tag or '_' in args.version_tag:
+        arg_version, arg_revision = re.split(r'[\-_]', args.version_tag)
+    else:
+        arg_version = args.version_tag
+        arg_revision = '1'
+
+    logging.debug('Version: %s, revision: %s' % (arg_version, arg_revision))
+
+    logging.info('Creating "%s" package from "%s"...' % (args.type, args.input_dir,))
+    package_generator.generate_package(
+        input_dir=args.input_dir,
+        version=arg_version,
+        revision=arg_revision,
+        output_file=args.output_file,
+        config=config,
+    )
+
+    if not os.path.isfile(args.output_file):
+        MeCabPackageException('Created package "%s" does not exist.' % args.output_file)
+    logging.info('Created package at "%s".' % args.output_file)
+
+    if args.bintray_descriptor_file:
+        logging.info('Creating Bintray descriptor to "%s"...' % args.bintray_descriptor_file)
+        with open(args.bintray_descriptor_file, 'w') as bintray_descriptor:
+            bintray_descriptor.write(
+                bintray_descriptor_json(
+                    bintray_repository_name=args.bintray_repository_name,
+                    bintray_subject=args.bintray_subject,
+                    version=arg_version,
+                    revision=arg_revision,
+                    version_tag=args.version_tag,
+                    package_path=args.output_file,
+                    config=config,
+                )
+            )
+        logging.info('Created Bintray descriptor to "%s".' % args.bintray_descriptor_file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What is this PR for?

Building + installing mecab-ipadic-neologd and keeping track of dictionary changes is a difficult process for users. I thereby suggest that you should build mecab-ipadic-neologd automatically on Travis, package it into `.deb` / `.rpm` / `.tgz` packages, and publish those packages on both Bintray (easy installation via APT / YUM) and GitHub Releases (easier to access, unlimited bandwidth).

## This PR includes

- A script (`libexec/create_package.py`) that creates `.deb` / `.rpm` / `.tgz` packages out of pre-built mecab-ipadic-neologd
- `.travis.yml` changes neccessary for building the packages and uploading them to both Bintray and GitHub Releases
- Installation instructions for APT / YUM package managers in README

## What type of PR is it?

Feature I guess.

## What is the issue?

Hi there!

[We](https://github.com/berkmancenter/mediacloud), as users of mecab-ipadic-neologd, find it a bit hard to keep track of changes in your neologism dictionary and keep our application up-to-date. Upon every periodic change, one has to check out the whole massive Git repository and rebuild everything; if the library has to be deployed to multiple servers, that forces us to create an ad-hoc package to be able to do that.

Would you consider pre-building and publishing mecab-ipadic-neologd packages on your end? I wrote a Python script that generates `.deb` (for Debian / Ubuntu), `.rpm` (for Red Hat / CentOS) and `.tgz` (for the rest, e.g. macOS) packages out of a build mecab-ipadic-neologd, and set up Travis CI (via `.travis.yml`) to publish those packages both to Bintray (which supports hosting APT / YUM repositories and is free for opensource projects) and GitHub Releases.

With my proposed setup, the release process is as follows:

1. Developer (you) would create a new Git tag with a release date and push it to GitHub, e.g.:

    ```bash
    git tag 20190913-1
    git push --tags
    ```

2. Travis would then build the tag, generate all three types of packages, and upload them to Bintray / GitHub releases:

    https://travis-ci.org/pypt/mecab-ipadic-neologd-publish-builds/builds/584629584

3. Pre-build packages would then end up on Bintray:

    https://bintray.com/neologd-unofficial

    and the users could then install them as any other APT / YUM package by simply following the instructions:

    https://github.com/pypt/mecab-ipadic-neologd-publish-builds/tree/publish_builds#installing-mecab-ipadic-neologd

    Alternatively, users could download `.deb` / `.rpm` / .tgz` packages from GitHub Releases:

    https://github.com/pypt/mecab-ipadic-neologd-publish-builds/releases/tag/20190913-1

Would you consider setting up such automated releases? There's a bit of an initial hassle to set everything up (with API keys and such), but I'm sure that would make your users' life considerably easier!

## How should this be tested?

To test it out on your end, you'd have to:

1. Sign up for a personal [Bintray](https://bintray.com/) account. Accounts for open-source projects are free, with 10 TB quota. I'd advise to call it something like `neologd-uploads` as you'll need to use `neologd` for an organization name later.
2. Create a new organization on Bintray, call it `neologd` or something similar.
3. Create three repositories in the newly created organization: `mecab-ipadic-neologd-rpm` (YUM repository), `mecab-ipadic-neologd-deb` (DEB repository) and `mecab-ipadic-neologd-tgz` (generic repository).
4. Create a [GitHub machine](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users) user and give it write permissions to your main mecab-ipadic-neologd repository for this user to be able to publish to GitHub Releases.
5. Merge this PR.
6. Do the following changes:
    1. Update GitHub OAuth token and set it to your GitHub machine user's personal token; search for `GITHUB_OAUTH_TOKEN` in the repository for instructions
    2. Update Bintray username and set it to your Bintray username (e.g. `neologd-uploads`); search for `BINTRAY_USERNAME`
    3. Update Bintray API key and set it to your Bintray API key; search for `BINTRAY_API_KEY`
    4. Update Bintray subject and set it to your Bintray organization name (e.g. `neologd`); search for `BINTRAY_SUBJECT`
    5. Update `PackageConfig` class and set various parameters, e.g. package summary, vendor, maintainer, URL, etc., to your likeness; search for `class PackageConfig`
    6. Update English `README.md` and make Travis CI build badge URL to point back to your own repository; search for `pypt/mecab-ipadic-neologd-publish-builds`
    7. Update English `README.md` and make the *Installing mecab-ipadic-NEologd* section point to your own Bintray repositories; search for `Installing mecab-ipadic-NEologd` or `neologd-unofficial`
    8. Update Japanese `README.ja.md` and add translated installation instructions from English `README.md` as yours truly isn't much of a Japanese speaker :)
7. `git push` your changes
8. Create a new release by tagging and pushing a commit with, say, today's date:

    ```
    git tag 20190913-1
    git push --tags
    ```

    and then make sure that the packages manage to build on your Travis and end up on both Bintray and GitHub Releases as expected.

Please don't hesitate to let me know if you have any questions, concerns or are unconvinced.


