### PR TITLE
Fix error in installing into a missing directory

### DIFF
--- a/libexec/install-mecab-ipadic-neologd.sh
+++ b/libexec/install-mecab-ipadic-neologd.sh
@@ -52,8 +52,12 @@ done
 cd ${BUILT_DIC_DIR}
 
 CUR_USER_ID=`id | cut -d $'=' -f 2 | cut -d $'(' -f 1`
-DIR_USER_ID=`ls -na ${INSTALL_DIR_PATH%/*} | head -2 | tail -1 | awk '{ print $3 }'`
-if [ ${CUR_USER_ID} -eq ${DIR_USER_ID} ]; then
+if [ -d ${INSTALL_DIR_PATH%/*} ]; then
+    DIR_USER_ID=`ls -na ${INSTALL_DIR_PATH%/*} | head -2 | tail -1 | awk '{ print $3 }'`
+else
+    DIR_USER_ID=""
+fi
+if [ ! -z "${DIR_USER_ID}" ] && [ ${CUR_USER_ID} -eq ${DIR_USER_ID} ]; then
     echo "$ECHO_PREFIX ${INSTALL_DIR_PATH%/*} is current user's directory"
     if [ ${INSTALL_AS_SUDOER} -eq 1 ]; then
         echo "$ECHO_PREFIX Sudo make install to ${INSTALL_DIR_PATH}"


### PR DESCRIPTION
## What is this PR for?

This PR fixes an error in installing mecab-ipadic-NEologd into a missing directory.

## This PR includes

- A modified version of `libexec/install-mecab-ipadic-neologd.sh`

## What type of PR is it?

Bugfix

## What is the issue?

The following error sometimes occurs:
```
ls: cannot access '/usr/lib/x86_64-linux-gnu/mecab/dic': No such file or directory
/mecab-ipadic-neologd/bin/../libexec/install-mecab-ipadic-neologd.sh: line 56: [: 0: unary operator expected
```
This happens when a user install `mecab` and `mecab-ipadic-utf8` on Ubuntu by apt.
The package manager installs the dictionaries into `/var/lib/mecab/dic`.
However, the default location for dictionaries, indicated by `mecab-config --dicdir`, is set to `/usr/lib/x86_64-linux-gnu/mecab/dic`, which has not been created.
Thus, installation script fails in running `ls`.
This error is not critical because the following processes run successfully even when it happens.
Possibly, this is a bug of MeCab or the package manager, but it is safer to check if the directory exist. 

## How should this be tested?

Create a new Ubuntu machine and install `mecab` and `mecab-ipadic-utf8`.
Then, install `mecab-ipadic-NEologd` without editing `mecabrc`. 