### PR TITLE
Use the latest URL of groonga-release

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -133,7 +133,7 @@ apt、yum や homebrew でインストールするか、自前でコンパイル
 #### 例: 動作に必要なライブラリのインストール
 - CentOS の場合
 
-    $ sudo rpm -ivh http://packages.groonga.org/centos/groonga-release-1.1.0-1.noarch.rpm
+    $ sudo yum install http://packages.groonga.org/centos/7/groonga-release-latest.noarch.rpm
 
     $ sudo yum install mecab mecab-devel mecab-ipadic git make curl xz patch
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please install at any time other lack library.
 #### Examples
 - On CentOS
 
-    $ sudo rpm -ivh http://packages.groonga.org/centos/groonga-release-1.1.0-1.noarch.rpm
+    $ sudo yum install http://packages.groonga.org/centos/7/groonga-release-latest.noarch.rpm
 
     $ sudo yum install mecab mecab-devel mecab-ipadic git make curl xz patch
 


### PR DESCRIPTION
## What is this PR for?

This PR updates the URL of groonga-release to the latest.
Because currently, the URL of groonga-release in README is old.

## This PR includes

- The latest URL of groonga-release

## What type of PR is it?

Improvement

## What is the issue?

N/A

## How should this be tested?

We execute the following command in CentOS

```shell
$ sudo yum install http://packages.groonga.org/centos/7/groonga-release-latest.noarch.rpm
```