### PR TITLE
Fix for hash calculation & slow download

### DIFF
--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -78,10 +78,10 @@ if [ ! -e ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz ]; then
     fi
 
     ORG_DIC_URL_LIST=()
-    # download from ja.osdn.net
-    ORG_DIC_URL_LIST[0]="https://ja.osdn.net/frs/g_redir.php?m=kent&f=mecab%2Fmecab-ipadic%2F2.7.0-20070801%2F${ORG_DIC_NAME}.tar.gz"
     # download from google drive
-    ORG_DIC_URL_LIST[1]="https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM"
+    ORG_DIC_URL_LIST[0]="https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM"
+    # download from ja.osdn.net
+    ORG_DIC_URL_LIST[1]="https://ja.osdn.net/frs/g_redir.php?m=kent&f=mecab%2Fmecab-ipadic%2F2.7.0-20070801%2F${ORG_DIC_NAME}.tar.gz"
     # download from sourceforge
     ORG_DIC_URL_LIST[2]="https://sourceforge.net/projects/mecab/files/mecab-ipadic/2.7.0-20070801/mecab-ipadic-2.7.0-20070801.tar.gz/download?use_mirror=autoselect#"
     for (( I = 0; I < ${#ORG_DIC_URL_LIST[@]}; ++I ))
@@ -97,7 +97,8 @@ if [ ! -e ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz ]; then
 	TMP_IPADIC_HASH_VAL=`openssl sha1 ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz | cut -d $' ' -f 2,2`
         if [ "${TMP_IPADIC_HASH_VAL}" != "0d9d021853ba4bb4adfa782ea450e55bfe1a229b" ]; then
             echo ""
-            echo "Hash value of ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz don't match"
+            echo "Hash value of ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz"
+            echo "    ${TMP_IPADIC_HASH_VAL} != 0d9d021853ba4bb4adfa782ea450e55bfe1a229b"
         else
             echo "Hash value of ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz matched"
             break 1;

--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -528,6 +528,6 @@ ${MECAB_LIBEXEC_DIR}/mecab-dict-index -f UTF8 -t UTF8
 echo "${ECHO_PREFIX} Make custom system dictionary on ${BASEDIR}/../build/${NEOLOGD_DIC_NAME}"
 make
 # for Ubuntu Linux on Windows 10
-# sed -i -e "s|${MECAB_DIC_DIR}/ipadic|${INSTALL_DIR_PATH}|g" ${NEOLOGD_DIC_DIR}/Makefile
+sed -i -e "s|${MECAB_DIC_DIR}/ipadic|${INSTALL_DIR_PATH}|g" ${NEOLOGD_DIC_DIR}/Makefile
 
 echo "$ECHO_PREFIX Finish.."

--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -94,7 +94,7 @@ if [ ! -e ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz ]; then
             echo "$ECHO_PREFIX Please check your network to download '${ORG_DIC_URL_LIST[${I}]}'"
             continue 1
 	fi
-	TMP_IPADIC_HASH_VAL=`openssl sha1 ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz | cut -d $' ' -f 2,2`
+	TMP_IPADIC_HASH_VAL=`openssl sha1 ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz | cut -d $' ' -f 2,2 | xargs`
         if [ "${TMP_IPADIC_HASH_VAL}" != "0d9d021853ba4bb4adfa782ea450e55bfe1a229b" ]; then
             echo ""
             echo "Hash value of ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz"

--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -528,6 +528,6 @@ ${MECAB_LIBEXEC_DIR}/mecab-dict-index -f UTF8 -t UTF8
 echo "${ECHO_PREFIX} Make custom system dictionary on ${BASEDIR}/../build/${NEOLOGD_DIC_NAME}"
 make
 # for Ubuntu Linux on Windows 10
-sed -i -e "s|${MECAB_DIC_DIR}/ipadic|${INSTALL_DIR_PATH}|g" ${NEOLOGD_DIC_DIR}/Makefile
+# sed -i -e "s|${MECAB_DIC_DIR}/ipadic|${INSTALL_DIR_PATH}|g" ${NEOLOGD_DIC_DIR}/Makefile
 
 echo "$ECHO_PREFIX Finish.."

--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -108,7 +108,7 @@ else
     echo "$ECHO_PREFIX Original mecab-ipadic file is already there."
 fi
 
-IPADIC_HASH_VAL=`openssl sha1 ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz | cut -d $' ' -f 2,2`
+IPADIC_HASH_VAL=`openssl sha1 ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz | cut -d $' ' -f 2,2 | xargs`
 if [ "${IPADIC_HASH_VAL}" != "0d9d021853ba4bb4adfa782ea450e55bfe1a229b" ]; then
     echo "$ECHO_PREFIX Fail to download ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz"
     echo "$ECHO_PREFIX You should remove ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz before retrying to install mecab-ipadic-NEologd"

--- a/libexec/make-mecab-ipadic-neologd.sh
+++ b/libexec/make-mecab-ipadic-neologd.sh
@@ -98,7 +98,7 @@ if [ ! -e ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz ]; then
         if [ "${TMP_IPADIC_HASH_VAL}" != "0d9d021853ba4bb4adfa782ea450e55bfe1a229b" ]; then
             echo ""
             echo "Hash value of ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz"
-            echo "    ${TMP_IPADIC_HASH_VAL} != 0d9d021853ba4bb4adfa782ea450e55bfe1a229b"
+            echo "    '${TMP_IPADIC_HASH_VAL}' != '0d9d021853ba4bb4adfa782ea450e55bfe1a229b'"
         else
             echo "Hash value of ${BASEDIR}/../build/${ORG_DIC_NAME}.tar.gz matched"
             break 1;


### PR DESCRIPTION
## What is this PR for?

- #88
- #84

## This PR includes

- Use `xargs` to remove whitespace from calculated hash
- Change download priority to use Google Drive before OSDN

## What type of PR is it?

Bugfix

## What is the issue?

- On Alpine Linux Docker image, hash calculation fails (#88)
- OSDN server is very slow for downloads, Google Drive is much faster (#84)

## How should this be tested?

Run install-mecab-ipadic-neologd script on Alpine Linux Docker image.
